### PR TITLE
chore: implement WPCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Ignore system files and temporary files
+.DS_Store
+Thumbs.db
+
+# Dependency directories
+vendor/
+
+# Lock files
+composer.lock

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# AI Search Plugin
+
+Replaces the default search with an intelligent search system.
+
+## Installation
+
+Clone the repository and install dependencies:
+
+```bash
+composer install
+```
+
+## Coding Standards
+
+This project uses [WordPress Coding Standards (WPCS)](https://github.com/WordPress/WordPress-Coding-Standards) via PHP\_CodeSniffer.
+
+### Commands
+
+- Check for coding standards issues:
+
+```bash
+composer lint
+```
+
+- Automatically fix fixable coding standards issues:
+
+```bash
+composer fix
+```
+
+### Configuration
+
+Coding standards are defined in the `phpcs.xml` file. The following directories are excluded:
+
+- `vendor/`
+- `node_modules/`
+- `build/`
+- `dist/`

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "samuelsilvapt/ai-search",
+    "description": "Replaces the default search with an intelligent search system.",
+    "type": "project",
+    "authors": [
+        {
+            "name": "samuelsilvapt",
+            "email": "hi@samuelsilva.pt"
+        }
+    ],
+    "require-dev": {
+        "squizlabs/php_codesniffer": "^3.12",
+        "wp-coding-standards/wpcs": "^3.1"
+    },
+    "scripts": {
+        "lint": "vendor/bin/phpcs --standard=phpcs.xml",
+        "fix": "vendor/bin/phpcbf --standard=phpcs.xml"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,12 @@
     ],
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.12",
-        "wp-coding-standards/wpcs": "^3.1"
+        "wp-coding-standards/wpcs": "^3.1",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
     },
     "scripts": {
-        "lint": "vendor/bin/phpcs --standard=phpcs.xml",
-        "fix": "vendor/bin/phpcbf --standard=phpcs.xml"
+        "lint": "vendor/bin/phpcs --standard=phpcs.xml --colors ai-search.php",
+        "fix": "vendor/bin/phpcbf --standard=phpcs.xml --colors ai-search.php"
     },
     "config": {
         "allow-plugins": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset name="AI Search Plugin Coding Standards">
+    <description>
+        WordPress Coding Standards for AI Search Plugin.
+    </description>
+
+    <rule ref="WordPress-Core" />
+    <rule ref="WordPress-Docs" />
+    <rule ref="WordPress-Extra" />
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals" />
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>node_modules/*</exclude-pattern>
+    <exclude-pattern>build/*</exclude-pattern>
+    <exclude-pattern>dist/*</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
- Added `php_codesniffer` and `wp-coding-standards/wpcs` via Composer.
- Created `phpcs.xml` configuration file with WordPress-Core, -Docs, -Extra, and prefix rules.
- Set up Composer scripts for `lint` and `fix` commands.
- Excluded vendor, build, dist, and node_modules directories from checks.